### PR TITLE
POC for rbenv hook/plugin

### DIFF
--- a/bin/rbenv_hook_install.sh
+++ b/bin/rbenv_hook_install.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+PREFIX_MAN="$(rbenv prefix)/share/man"
+mkdir -p "${PREFIX_MAN}"
+
+RBENV_ROOT=`rbenv root`
+
+HOOK_DIR="${RBENV_ROOT}/plugins/tst/etc/rbenv.d/exec"
+
+mkdir -p $HOOK_DIR
+
+cp "${DIR}/../lib/version-name-change-man.bash" $HOOK_DIR/
+
+gem install manpages
+
+ln -s $PREFIX_MAN "${RBENV_ROOT}/man"
+
+cat <<EOM
+# add the following to ~/.bashrc:
+MANPATH="${RBENV_ROOT}/man:\${MANPATH}"
+EOM
+

--- a/bin/rbenv_hook_install.sh
+++ b/bin/rbenv_hook_install.sh
@@ -6,7 +6,8 @@ if ! $(gem list -i manpages) ;then
   gem install manpages
 fi
 
-if [ -d "$(readlink -f ${SCRIPT_DIR}/.git)" ]; then
+if [[ -n "$(command -v git)" && \
+        "$(basename $(git config --local remote.origin.url))" == "manpages.git" ]]; then
   DIR=$SCRIPT_DIR
 else
   LIB_DIR="$(dirname "$(gem which manpages)")"

--- a/bin/rbenv_hook_install.sh
+++ b/bin/rbenv_hook_install.sh
@@ -13,20 +13,23 @@ else
   DIR="$(readlink -f  ${LIB_DIR}/../)"
 fi
 
-source ${DIR}/libexec/vars.sh
+if [ "$DIR" != "$(rbenv root)" ]; then
+  source ${DIR}/libexec/vars.sh
 
-mkdir -p "${PREFIX_MAN}"
+  mkdir -p "${PREFIX_MAN}"
 
-mkdir -p $EXEC_HOOK_DIR
-mkdir -p $INSTALL_HOOK_DIR
+  mkdir -p $EXEC_HOOK_DIR
+  mkdir -p $INSTALL_HOOK_DIR
 
-cp "${DIR}/lib/version-name-change-man.bash" $EXEC_HOOK_DIR/
-cp "${DIR}/lib/install-man.bash" $INSTALL_HOOK_DIR/
+  cp "${DIR}/lib/version-name-change-man.bash" $EXEC_HOOK_DIR/
+  cp "${DIR}/lib/install-man.bash" $INSTALL_HOOK_DIR/
 
-ln -s $PREFIX_MAN "${RBENV_ROOT}/man"
+  ln -s $PREFIX_MAN "${RBENV_ROOT}/man"
 
 cat <<EOM
-# add the following to ~/.bashrc:
+  # add the following to ~/.bashrc:
 MANPATH="${RBENV_ROOT}/man:\${MANPATH}"
 EOM
-
+else
+  echo "cannot find gem folder"
+fi

--- a/bin/rbenv_hook_install.sh
+++ b/bin/rbenv_hook_install.sh
@@ -2,8 +2,11 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
 
-if ! $(gem list -i manpages) ;then
-  gem install manpages
+if [ -z $GEM_NAME ]; then
+  GEM_NAME="manpages"
+fi
+if ! $(gem list -i "$GEM_NAME") ;then
+  gem install "$GEM_NAME"
 fi
 
 if [[ -n "$(command -v git)" && \

--- a/bin/rbenv_hook_install.sh
+++ b/bin/rbenv_hook_install.sh
@@ -2,18 +2,15 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-PREFIX_MAN="$(rbenv prefix)/share/man"
+source ${DIR}/../libexec/vars.sh
+
 mkdir -p "${PREFIX_MAN}"
 
-RBENV_ROOT=`rbenv root`
+mkdir -p $EXEC_HOOK_DIR
+mkdir -p $INSTALL_HOOK_DIR
 
-HOOK_DIR="${RBENV_ROOT}/plugins/tst/etc/rbenv.d/exec"
-
-mkdir -p $HOOK_DIR
-
-cp "${DIR}/../lib/version-name-change-man.bash" $HOOK_DIR/
-
-gem install manpages
+cp "${DIR}/../lib/version-name-change-man.bash" $EXEC_HOOK_DIR/
+cp "${DIR}/../lib/install-man.bash" $INSTALL_HOOK_DIR/
 
 ln -s $PREFIX_MAN "${RBENV_ROOT}/man"
 

--- a/bin/rbenv_hook_install.sh
+++ b/bin/rbenv_hook_install.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
 
-source ${DIR}/../libexec/vars.sh
+if ! $(gem list -i manpages) ;then
+  gem install manpages
+fi
+
+if [ -d "$(readlink -f ${SCRIPT_DIR}/.git)" ]; then
+  DIR=$SCRIPT_DIR
+else
+  LIB_DIR="$(dirname "$(gem which manpages)")"
+  DIR="$(readlink -f  ${LIB_DIR}/../)"
+fi
+
+source ${DIR}/libexec/vars.sh
 
 mkdir -p "${PREFIX_MAN}"
 
 mkdir -p $EXEC_HOOK_DIR
 mkdir -p $INSTALL_HOOK_DIR
 
-cp "${DIR}/../lib/version-name-change-man.bash" $EXEC_HOOK_DIR/
-cp "${DIR}/../lib/install-man.bash" $INSTALL_HOOK_DIR/
+cp "${DIR}/lib/version-name-change-man.bash" $EXEC_HOOK_DIR/
+cp "${DIR}/lib/install-man.bash" $INSTALL_HOOK_DIR/
 
 ln -s $PREFIX_MAN "${RBENV_ROOT}/man"
 

--- a/bin/remove_hook_folders.sh
+++ b/bin/remove_hook_folders.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source ${DIR}/../libexec/vars.sh
+echo "removing ${ROOT_MAN}"
+rm -rf "${ROOT_MAN}"
+echo "removing ${PREFIX_MAN}"
+rm -rf "${PREFIX_MAN}"
+echo "removing ${INSTALL_HOOK_DIR}"
+rm -rf "${INSTALL_HOOK_DIR}"
+echo "removing ${EXEC_HOOK_DIR}"
+rm -rf "${EXEC_HOOK_DIR}"

--- a/bin/remove_hook_folders.sh
+++ b/bin/remove_hook_folders.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
 
-source ${DIR}/../libexec/vars.sh
+source ${DIR}/libexec/vars.sh
 echo "removing ${ROOT_MAN}"
 rm -rf "${ROOT_MAN}"
 echo "removing ${PREFIX_MAN}"
@@ -10,3 +10,5 @@ echo "removing ${INSTALL_HOOK_DIR}"
 rm -rf "${INSTALL_HOOK_DIR}"
 echo "removing ${EXEC_HOOK_DIR}"
 rm -rf "${EXEC_HOOK_DIR}"
+
+gem uninstall manpages

--- a/bin/remove_hook_folders.sh
+++ b/bin/remove_hook_folders.sh
@@ -11,4 +11,8 @@ rm -rf "${INSTALL_HOOK_DIR}"
 echo "removing ${EXEC_HOOK_DIR}"
 rm -rf "${EXEC_HOOK_DIR}"
 
-gem uninstall manpages
+if [ -z $GEM_NAME ]; then
+  GEM_NAME="manpages"
+fi
+
+gem uninstall "$GEM_NAME"

--- a/lib/install-man.bash
+++ b/lib/install-man.bash
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if declare -Ff after_install >/dev/null; then
+  after_install install_manpages
+else
+  echo "rbenv: rbenv-default-gems plugin requires ruby-build 20130129$
+fi
+
+install_manpages() {
+  rbenv-exec gem install "manpages" < /dev/null || {
+        echo "rbenv: error installing gem \`manpages'"
+  } >&2
+}

--- a/lib/manpages/version.rb
+++ b/lib/manpages/version.rb
@@ -1,3 +1,3 @@
 module Manpages
-  VERSION = "0.2.2"
+  VERSION = "0.3.0"
 end

--- a/lib/version-name-change-man.bash
+++ b/lib/version-name-change-man.bash
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+ROOT_MAN="$(rbenv root)/man"
+PREFIX_MAN="$(rbenv prefix)/share/man"
+
+if [ "$(readlink $ROOT_MAN)" != "$PREFIX_MAN" ]; then
+  rm -rf "${ROOT_MAN}"
+  ln -s "${PREFIX_MAN}" "${ROOT_MAN}"
+fi

--- a/lib/version-name-change-man.bash
+++ b/lib/version-name-change-man.bash
@@ -1,9 +1,15 @@
 #!/bin/bash
 
+set -e
+[ -n "$RBENV_DEBUG" ] && set -x
+
 ROOT_MAN="$(rbenv root)/man"
 PREFIX_MAN="$(rbenv prefix)/share/man"
 
 if [ "$(readlink $ROOT_MAN)" != "$PREFIX_MAN" ]; then
+  [ -n "$RBENV_DEBUG" ] && echo "removing ${ROOT_MAN}"
   rm -rf "${ROOT_MAN}"
+  [ -n "$RBENV_DEBUG" ] && echo "linking ${PREFIX_MAN} -> ${ROOT_MAN}"
   ln -s "${PREFIX_MAN}" "${ROOT_MAN}"
 fi
+

--- a/libexec/vars.sh
+++ b/libexec/vars.sh
@@ -1,0 +1,6 @@
+RBENV_ROOT=`rbenv root`
+
+PREFIX_MAN="$(rbenv prefix)/share/man"
+ROOT_MAN="${RBENV_ROOT}/man"
+EXEC_HOOK_DIR="${RBENV_ROOT}/plugins/manpages/etc/rbenv.d/exec"
+INSTALL_HOOK_DIR="${RBENV_ROOT}/plugins/manpages/etc/rbenv.d/install"


### PR DESCRIPTION
steps 
1. download https://github.com/jtzero/manpages/releases/download/0.3.0/manpages-0.3.0.gem
2. GEM_NAME='manpages-0.3.0.gem' curl -o- https://raw.githubusercontent.com/jtzero/manpages/0.3.0/bin/rbenv_hook_install.sh | bash
4. as it says in the after install update the MANPATH to $(rbenv root)/man
5. reload shell
3. just as you would expect install a gem that has a manpage (guard) it will show up under man command

addendum: the GEM_NAME in step two is just for testing, by default it will pull the one from rubygems.org

implementation: creates symlinks in each version of the of ruby installed (this is done by the gem by default) and the hook creates a  creates a symlink $(rbenv root)/man that is relinked to  the current version running. 
