### PR TITLE
Fix regex for determining man page file

### DIFF
--- a/lib/manpages/man_files.rb
+++ b/lib/manpages/man_files.rb
@@ -17,7 +17,7 @@ module Manpages
       return [] unless man_dir.directory?
 
       man_dir.children(false).select do |file|
-        file.extname =~ /.\d$/
+        file.extname =~ /\.\d$/
       end.map {|file| man_dir.join(file) }
     end
 


### PR DESCRIPTION
The regular expression for determining a man page file uses a plain `.` but what is, in all probability, meant is `\.`, that is the dot character itself.