### PR TITLE
Use all man pages inside `man` directory

### DIFF
--- a/lib/manpages/man_files.rb
+++ b/lib/manpages/man_files.rb
@@ -16,9 +16,9 @@ module Manpages
     def manpages
       return [] unless man_dir.directory?
 
-      man_dir.children(false).select do |file|
-        file.extname =~ /\.\d$/
-      end.map {|file| man_dir.join(file) }
+      Dir[man_dir.join("**/*")].select do |file|
+        file =~ /\.\d$/
+      end.map {|file| Pathname.new(file) }
     end
 
     def man_file_path(file)

--- a/spec/manpages/install_spec.rb
+++ b/spec/manpages/install_spec.rb
@@ -10,6 +10,7 @@ describe Manpages::Install do
     expect(Dir.glob("spec/tmp/man/**/*")).to match_array [
       "spec/tmp/man/man1",
       "spec/tmp/man/man1/example.1",
+      "spec/tmp/man/man1/extra.1",
       "spec/tmp/man/man2",
       "spec/tmp/man/man2/example.2",
     ]
@@ -69,7 +70,8 @@ describe Manpages::Install do
       ).install_manpages
     end.to output(
       "Problems creating symlink spec/tmp/man/man1/example.1\n" \
-      "Problems creating symlink spec/tmp/man/man2/example.2\n"
+      "Problems creating symlink spec/tmp/man/man2/example.2\n" \
+      "Problems creating symlink spec/tmp/man/man1/extra.1\n"
     ).to_stdout
     FileUtils.rm_r "spec/tmp"
   end

--- a/spec/manpages/man_files_spec.rb
+++ b/spec/manpages/man_files_spec.rb
@@ -6,6 +6,7 @@ describe Manpages::ManFiles do
       expect(Manpages::ManFiles.new("spec/data", "").manpages.map(&:to_s)).to match_array [
         "spec/data/man/example.1",
         "spec/data/man/example.2",
+        "spec/data/man/man1/extra.1",
       ]
     end
   end


### PR DESCRIPTION
The `man` command allows placing manual pages either directly inside a `man` directory or inside the `man1`, `man2`, ... directories. Also use the files in the nested directories.