### PR TITLE
Bugfix: require missing FileUtils

### DIFF
--- a/lib/manpages/install.rb
+++ b/lib/manpages/install.rb
@@ -1,4 +1,4 @@
-require 'fileutils'
+require "fileutils"
 
 module Manpages
   class Install
@@ -27,8 +27,8 @@ module Manpages
       begin
         FileUtils.mkdir_p(man_target_file.dirname)
         FileUtils.ln_s(file, man_target_file, force: true)
-      rescue
-        puts "Problems creating symlink #{man_target_file}"
+      rescue => e
+        puts "Problems creating symlink #{man_target_file}: #{e}"
       end
     end
   end

--- a/lib/manpages/install.rb
+++ b/lib/manpages/install.rb
@@ -27,8 +27,8 @@ module Manpages
       begin
         FileUtils.mkdir_p(man_target_file.dirname)
         FileUtils.ln_s(file, man_target_file, force: true)
-      rescue => e
-        puts "Problems creating symlink #{man_target_file}: #{e}"
+      rescue
+        puts "Problems creating symlink #{man_target_file}"
       end
     end
   end

--- a/lib/manpages/install.rb
+++ b/lib/manpages/install.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 module Manpages
   class Install
     def initialize(gem_spec, gem_dir, target_dir)


### PR DESCRIPTION
This PR adds a `require` which makes the `gem manpages --update-all` invocation work again.

---

For my own edification, I added the error output to the puts in the `install` functionality. The output on failure (before this minor fix) was:

```
Installing man pages for hexapdf 0.3.0
Problems creating symlink /Users/olle/.gem/ruby/2.4.0/share/man/man1/hexapdf.1 uninitialized constant Manpages::Install::FileUtils
Did you mean?  FileTest
```

I removed it, as it made the error message matching tedious (not very generous tests, those exact-string-matchers!).