### PR TITLE
fix: bump rake, rubocop, and rexml to resolve HIGH/MEDIUM CVEs.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem "rexml", ">= 3.3.9", group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,54 +6,105 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.0)
-    coderay (1.1.2)
-    diff-lcs (1.3)
-    jaro_winkler (1.5.4)
-    method_source (0.9.2)
-    parallel (1.19.1)
-    parser (2.7.0.3)
-      ast (~> 2.4.0)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    rainbow (3.0.0)
-    rake (10.5.0)
-    rexml (3.2.4)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.1)
-      rspec-support (~> 3.9.1)
-    rspec-expectations (3.9.0)
+    ast (2.4.3)
+    coderay (1.1.3)
+    diff-lcs (1.6.2)
+    io-console (0.8.2)
+    json (2.19.5)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    method_source (1.1.0)
+    parallel (2.1.0)
+    parser (3.3.11.1)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
+    pry (0.16.0)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+      reline (>= 0.6.0)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    rake (13.4.2)
+    regexp_parser (2.12.0)
+    reline (0.6.3)
+      io-console (~> 0.5)
+    rexml (3.4.4)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.2)
-    rubocop (0.80.1)
-      jaro_winkler (~> 1.5.1)
-      parallel (~> 1.10)
-      parser (>= 2.7.0.1)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+    rubocop (1.86.1)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (>= 1.10)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      rexml
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
-    ruby-progressbar (1.10.1)
-    unicode-display_width (1.6.1)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.49.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
 
 PLATFORMS
+  arm64-darwin-25
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.8)
+  bundler (>= 2.0)
   manpages!
   pry (~> 0)
-  rake (~> 10.0)
+  rake (~> 13.0)
+  rexml (>= 3.3.9)
   rspec (~> 3.0)
-  rubocop (~> 0.80.1)
+  rubocop (~> 1.0)
+
+CHECKSUMS
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
+  diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
+  json (2.19.5) sha256=218a18553e4801d579ca7e0f5bc72bafd776d7397238a1fb4e74db5b0a812c59
+  language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
+  manpages (0.6.1)
+  method_source (1.1.0) sha256=181301c9c45b731b4769bc81e8860e72f9161ad7d66dd99103c9ab84f560f5c5
+  parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
+  parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  pry (0.16.0) sha256=d76c69065698ed1f85e717bd33d7942c38a50868f6b0673c636192b3d1b6054e
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
+  rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
+  rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
+  rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
+  rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
+  rubocop (1.86.1) sha256=44415f3f01d01a21e01132248d2fd0867572475b566ca188a0a42133a08d4531
+  rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
 
 BUNDLED WITH
-   1.17.3
+  4.0.6

--- a/manpages.gemspec
+++ b/manpages.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) {|f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.8"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", ">= 2.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry", "~> 0"
-  spec.add_development_dependency "rubocop", "~> 0.80.1"
+  spec.add_development_dependency "rubocop", "~> 1.0"
 end


### PR DESCRIPTION
These gems were flagged by `trivy`:

```shell
Gemfile.lock (bundler)

Total: 8 (UNKNOWN: 0, LOW: 0, MEDIUM: 5, HIGH: 3, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────┬───────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │          Fixed Version           │                           Title                           │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────┼───────────────────────────────────────────────────────────┤
│ rake    │ CVE-2020-8130  │ HIGH     │ fixed  │ 10.5.0            │ >= 12.3.3                        │ rake: OS Command Injection via egrep in Rake::FileList    │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2020-8130                 │
├─────────┼────────────────┤          │        ├───────────────────┼──────────────────────────────────┼───────────────────────────────────────────────────────────┤
│ rexml   │ CVE-2021-28965 │          │        │ 3.2.4             │ ~> 3.1.9.1, ~> 3.2.3.1, >= 3.2.5 │ ruby: XML round-trip vulnerability in REXML               │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2021-28965                │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼───────────────────────────────────────────────────────────┤
│         │ CVE-2024-49761 │          │        │                   │ >= 3.3.9                         │ rexml: REXML ReDoS vulnerability                          │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-49761                │
│         ├────────────────┼──────────┤        │                   ├──────────────────────────────────┼───────────────────────────────────────────────────────────┤
│         │ CVE-2024-35176 │ MEDIUM   │        │                   │ >= 3.2.7                         │ REXML: DoS parsing an XML with many `<`s in an attribute  │
│         │                │          │        │                   │                                  │ value...                                                  │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-35176                │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼───────────────────────────────────────────────────────────┤
│         │ CVE-2024-39908 │          │        │                   │ >= 3.3.2                         │ rexml: DoS vulnerability in REXML                         │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-39908                │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼───────────────────────────────────────────────────────────┤
│         │ CVE-2024-41123 │          │        │                   │ >= 3.3.3                         │ rexml: rubygem-rexml: DoS when parsing an XML having many │
│         │                │          │        │                   │                                  │ specific characters such...                               │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-41123                │
│         ├────────────────┤          │        │                   │                                  ├───────────────────────────────────────────────────────────┤
│         │ CVE-2024-41946 │          │        │                   │                                  │ rexml: DoS vulnerability in REXML                         │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-41946                │
│         ├────────────────┤          │        │                   ├──────────────────────────────────┼───────────────────────────────────────────────────────────┤
│         │ CVE-2024-43398 │          │        │                   │ >= 3.3.6                         │ rexml: DoS vulnerability in REXML                         │
│         │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-43398                │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────┴───────────────────────────────────────────────────────────┘
```